### PR TITLE
Fixed macOS build errors when using a separate build directory

### DIFF
--- a/osxinstall/CMakeLists.txt
+++ b/osxinstall/CMakeLists.txt
@@ -52,18 +52,15 @@ TARGET_LINK_LIBRARIES(install_driver ${ODBC_INSTLIBS})#${PLATFORM_DEPENDENCIES})
 IF(USE_SYSTEM_INSTALLED_LIB)
   ADD_CUSTOM_TARGET(copypkgfiles
                   COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/copy_package_files.sh $<TARGET_FILE_DIR:maodbc>
-                  DEPENDS maodbc install_driver
-                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+                  DEPENDS maodbc install_driver)
 ELSE()
   ADD_CUSTOM_TARGET(copypkgfiles
-                  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/copy_package_files.sh $<TARGET_FILE_DIR:maodbc> $<TARGET_FILE_DIR:dialog>
-                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+                  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/copy_package_files.sh $<TARGET_FILE_DIR:maodbc> $<TARGET_FILE_DIR:dialog>)
 ENDIF()
 
 ADD_CUSTOM_TARGET(maodbcpkg
-                  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/build_package.sh ${PRODUCT_IDENTIFIER} ${PRODUCT_VERSION} ${PKG_PACKAGE}
-                  DEPENDS copypkgfiles ${CMAKE_CURRENT_BINARY_DIR}/scripts/postinstall distribution.plist README.html WELCOME.html LICENSE.html
-                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+                  COMMAND ${CMAKE_CURRENT_BINARY_DIR}/build_package.sh ${PRODUCT_IDENTIFIER} ${PRODUCT_VERSION} ${PKG_PACKAGE}
+                  DEPENDS copypkgfiles ${CMAKE_CURRENT_BINARY_DIR}/scripts/postinstall ${CMAKE_CURRENT_BINARY_DIR}/distribution.plist README.html ${CMAKE_CURRENT_BINARY_DIR}/WELCOME.html LICENSE.html)
 
 SET_TARGET_PROPERTIES(maodbcpkg PROPERTIES EXCLUDE_FROM_ALL OFF)
 


### PR DESCRIPTION
The current build works only if the build directory is the source directory. Creating a separate build directory like:

```sh
mkdir build && cd build
cmake ..   # (options omitted for conciseness in demonstration purposes)
```

causes various errors on macOS.

Notably I made the following changes:

1. The copy package files and build package scripts now use the build directory as the working directory rather than the source directory. Besides now not polluting the source directory when requested not to, it fixes various errors in the script files due to them assuming they are in the build directory, such as the [`install_driver` binary copy in `copy_package_files.sh`](https://github.com/MariaDB/mariadb-connector-odbc/blob/9d2f2c8421477d1d69086a09f5bedf1ae906fb17/osxinstall/copy_package_files.sh#L27) and the [distribution.plist lookup in `build_packages.sh`](https://github.com/MariaDB/mariadb-connector-odbc/blob/9d2f2c8421477d1d69086a09f5bedf1ae906fb17/osxinstall/build_package.sh.in#L22).
2. Corrected the build package command to use `${CMAKE_CURRENT_BINARY_DIR}/build_package.sh` rather than `${CMAKE_CURRENT_SOURCE_DIR}/build_package.sh`. The source directory contains a `build_package.sh.in` file. Once configured, this is placed in the build directory.
3. Corrected the `distribution.plist` and `WELCOME.html` dependencies to look in the build directory. Again these are generated files, so we should look in the build directory for them rather than the source directory.

Consider this pull request submitted under BSD-new.