### PR TITLE
Fix implicit declarations on Linux

### DIFF
--- a/ma_common.c
+++ b/ma_common.c
@@ -21,6 +21,7 @@
  * Moved to avoid redundant dependencies */
 
 #include <ma_odbc.h>
+#include <wctype.h>
 
 static unsigned int ValidChar(const char *start, const char *end)
 {

--- a/ma_debug.c
+++ b/ma_debug.c
@@ -17,6 +17,7 @@
    51 Franklin St., Fifth Floor, Boston, MA 02110, USA
 *************************************************************************************/
 #include <ma_odbc.h>
+#include <wchar.h>
 
 #ifdef MAODBC_DEBUG
 extern char LogFile[];

--- a/ma_dsn.c
+++ b/ma_dsn.c
@@ -16,6 +16,7 @@
    or write to the Free Software Foundation, Inc., 
    51 Franklin St., Fifth Floor, Boston, MA 02110, USA
 *************************************************************************************/
+#define _GNU_SOURCE
 #include <ma_odbc.h>
 
 


### PR DESCRIPTION
ma_debug.c:47:5: warning: implicit declaration of function 'fwprintf'; did you mean 'fprintf'?
ma_dsn.c:284:15: warning: implicit declaration of function 'strcasestr'; did you mean 'strcasecmp'?
ma_common.c:45:17: warning: implicit declaration of function 'iswspace'