### PR TITLE
Fix initializer type for MADB_ErrorList

### DIFF
--- a/ma_error.c
+++ b/ma_error.c
@@ -144,7 +144,7 @@ MADB_ERROR MADB_ErrorList[] =
   { "S1000", "", "General error", SQL_ERROR},
   { "S1107", "", "Row value out of range", SQL_ERROR},
   { "S1C00", "", "Optional feature not implemented", SQL_ERROR},
-  { 0,0,0, -1}
+  { "", "", "", -1}
 };
 /* }}} */
 


### PR DESCRIPTION
The initializer { 0, 0, 0, -1 } results in an error entry of,
```
 {SqlState = "\000\000\000\377\000",
  SqlStateV2 = "\000\000\000\000\000",
  SqlErrorMsg = '\000' <repeats 512 times>,
  ReturnValue = 0}
```

The reason is that integers are converted to char initializers in the
SqlState char array and the remainder is set to 0. Instead, we should
use compatible types so no implicit conversion occurs. With this, the
entry becomes,

```
 {SqlState = "\000\000\000\000\000",
  SqlStateV2 = "\000\000\000\000\000",
  SqlErrorMsg = '\000' <repeats 512 times>,
  ReturnValue = -1}
```