### PR TITLE
Improve AIX support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,7 +255,7 @@ IF(NOT WIN32)
   ENDIF()
 ENDIF()
 
-IF(APPLE)
+IF(APPLE OR CMAKE_SYSTEM_NAME MATCHES AIX)
   # Looking for iconv files
   INCLUDE(${CMAKE_SOURCE_DIR}/cmake/FindIconv.cmake)
   IF(ICONV_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,7 +327,7 @@ ELSE()
                                      INSTALL_RPATH_USE_LINK_PATH 0
                                      BUILD_WITH_INSTALL_RPATH 1
                                      INSTALL_RPATH "${MAODBC_INSTALL_RPATH}")
-  ELSE()
+  ELSEIF(NOT CMAKE_SYSTEM_NAME MATCHES AIX)
     SET_TARGET_PROPERTIES(${LIBRARY_NAME} PROPERTIES LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/maodbc.def")
   ENDIF()
 ENDIF()

--- a/ma_dsn.c
+++ b/ma_dsn.c
@@ -284,7 +284,11 @@ my_bool MADB_DsnStoreValue(MADB_Dsn *Dsn, unsigned int DsnKeyIdx, char *Value, m
         IntValue= 0;
         for (i= 0; i < sizeof(TlsVersionBits); ++i)
         {
+#ifdef _AIX
+          if (strstr(Value, TlsVersionName[i]) != NULL)
+#else
           if (strcasestr(Value, TlsVersionName[i]) != NULL)
+#endif
           {
             IntValue|= TlsVersionBits[i];
           }


### PR DESCRIPTION
mariadb-connector-odbc currently cannot be built on AIX.
This patch add libiconv dependency, use of strstr (strcasestr is not available on AIX) and remove the "--version-script" not supported on AIX. Exportfile is made automatically by CMake on AIX.