### PR TITLE
s390x support: changes to fix test failures 

### DIFF
--- a/ma_connection.c
+++ b/ma_connection.c
@@ -586,7 +586,11 @@ SQLRETURN MADB_DbcConnectDB(MADB_Dbc *Connection,
     MADB_Dsn *Dsn)
 {
   char StmtStr[128];
+#if defined(__s390x__)
+   my_bool ReportDataTruncation= 1;
+#else   
   unsigned ReportDataTruncation= 1;
+#endif    
   unsigned int i;
   unsigned long client_flags= 0L;
   my_bool my_reconnect= 1;

--- a/test/basic.c
+++ b/test/basic.c
@@ -70,8 +70,11 @@ ODBC_TEST(test_CONO3)
 ODBC_TEST(simple_test)
 {
   SQLRETURN rc= SQL_SUCCESS;
-
+#if defined(__s390x__)
+  SQLSMALLINT value=3;
+#else	
   SQLINTEGER value=3;
+#endif	
   SQLWCHAR Buffer[20];
 
   char buffer[128];

--- a/test/param.c
+++ b/test/param.c
@@ -1491,6 +1491,9 @@ ODBC_TEST(odbc45)
 {
   SQLSMALLINT i;
   SQLLEN      len= 0;
+#if defined(__s390x__)
+  SQLCHAR     value;
+#endif  
   SQLCHAR     val[][4]=        {"0",            "1"};//, "4", "-1", "0.5", "z"},
   SQLWCHAR    valw[][4]=       { { '0', '\0' }, { '1', '\0' }, { '4', '\0' }, { '-', '1', '\0' }, { '0', '.', '5', '\0' }, { 'z', '\0' } };
   SQLRETURN   XpctdRc[]=       {SQL_SUCCESS,    SQL_SUCCESS, SQL_ERROR, SQL_ERROR, SQL_ERROR, SQL_ERROR};
@@ -1528,7 +1531,12 @@ ODBC_TEST(odbc45)
   for (i= 0; i<sizeof(XpctdValue); ++i)
   {
     CHECK_STMT_RC(Stmt, SQLFetch(Stmt));
+  #if defined(__s390x__)
+    SQLGetData(Stmt, 1, SQL_C_BIT, &value, sizeof(value), 0);
+    is_num(value, XpctdValue[i]);
+  #else  
     is_num(my_fetch_int(Stmt, 1), XpctdValue[i]);
+  #endif  
   }
 
   CHECK_STMT_RC(Stmt, SQLFreeStmt(Stmt, SQL_CLOSE));


### PR DESCRIPTION
Code changes required to fix the below test failures on s390x
1 - odbc_basic 
20 - odbc_error 
21 - odbc_param 

Please review.


