### PR TITLE
s390x support for Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
     - mariadb.example.com
 
 before_install:
+  - chmod +x .travis/s390x.sh
   - chmod 777 .travis/build/
   - export PROJ_PATH=`pwd`
   - export ENTRYPOINT=$PROJ_PATH/.travis/sql
@@ -68,9 +69,12 @@ matrix:
       env: DB=mysql:5.6
     - os: linux
       env: DB=mysql:5.7
+    - os: linux
+      arch: s390x
 
 script:
   - if [[ "$DB" == build* ]] ; then .travis/build/build.sh; fi
   - if [[ "$DB" == build* ]] ; then docker build -t build:10.6 --label build .travis/build/; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ] ; then .travis/script.sh; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$TRAVIS_ARCH" != "s390x" ] ; then .travis/script.sh; fi
+  - if [ "$TRAVIS_ARCH" = "s390x" ]; then .travis/s390x.sh; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then .travis/osx.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,5 +76,5 @@ script:
   - if [[ "$DB" == build* ]] ; then .travis/build/build.sh; fi
   - if [[ "$DB" == build* ]] ; then docker build -t build:10.6 --label build .travis/build/; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$TRAVIS_ARCH" != "s390x" ] ; then .travis/script.sh; fi
-  - if [ "$TRAVIS_ARCH" = "s390x" ]; then .travis/s390x.sh; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then .travis/osx.sh; fi
+  - if [ "$TRAVIS_ARCH" = "s390x" ]; then .travis/s390x.sh; fi

--- a/.travis/s390x.sh
+++ b/.travis/s390x.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -x
+set -e
+
+DEBIAN_FRONTEND=noninteractive sudo apt-get update
+DEBIAN_FRONTEND=noninteractive sudo apt-get install -y mariadb-server unixodbc-dev git cmake gcc libssl-dev tar curl libcurl4-openssl-dev libkrb5-dev 
+
+sudo service mysql start
+sudo ln -s /var/run/mysqld/mysqld.sock /tmp/mysql.sock
+sudo mysql -u root -e 'CREATE DATABASE IF NOT EXISTS test;'
+sudo mysql -u root -e "USE mysql; UPDATE user SET plugin='mysql_native_password' WHERE User='root'; FLUSH PRIVILEGES;"
+mysql --version
+
+# set variables for Connector/ODBC
+export TEST_DRIVER=maodbc_test
+export TEST_SCHEMA=test
+export TEST_DSN=maodbc_test
+export TEST_UID=root
+export TEST_PASSWORD=
+
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_OPENSSL=ON -DWITH_SSL=OPENSSL -DODBC_LIB_DIR=/usr/lib/s390x-linux-gnu/
+cmake --build . --config RelWithDebInfo 
+
+###################################################################################################################
+# run test suite
+###################################################################################################################
+
+echo "Running tests"
+
+cd test
+export ODBCINI="$PWD/odbc.ini"
+export ODBCSYSINI=$PWD
+
+ctest -V


### PR DESCRIPTION
As Travis CI [officially supports](https://blog.travis-ci.com/2019-11-12-multi-cpu-architecture-ibm-power-ibm-z) s390x builds, adding support for same.

