### PR TITLE
s390x support: Test failures fix

### DIFF
--- a/ma_statement.c
+++ b/ma_statement.c
@@ -971,6 +971,7 @@ SQLRETURN MADB_DoExecute(MADB_Stmt *Stmt, BOOL ExecDirect)
   /**************************** mysql_stmt_bind_param **********************************/
   if (ExecDirect)
   {
+    /* Use datatype same as MYSQL_STMT->prebind_param */ 
     unsigned int pCount = (unsigned int)Stmt->ParamCount;
     mysql_stmt_attr_set(Stmt->stmt, STMT_ATTR_PREBIND_PARAMS, &pCount);
   }

--- a/ma_statement.c
+++ b/ma_statement.c
@@ -971,7 +971,8 @@ SQLRETURN MADB_DoExecute(MADB_Stmt *Stmt, BOOL ExecDirect)
   /**************************** mysql_stmt_bind_param **********************************/
   if (ExecDirect)
   {
-    mysql_stmt_attr_set(Stmt->stmt, STMT_ATTR_PREBIND_PARAMS, &Stmt->ParamCount);
+    unsigned int pCount = (unsigned int)Stmt->ParamCount;
+    mysql_stmt_attr_set(Stmt->stmt, STMT_ATTR_PREBIND_PARAMS, &pCount);
   }
 
   mysql_stmt_attr_set(Stmt->stmt, STMT_ATTR_ARRAY_SIZE, (void*)&Stmt->Bulk.ArraySize);


### PR DESCRIPTION
On s390x, below tests are failing due to seg. fault. 
          1 - odbc_basic (SEGFAULT)
          2 - odbc_types (SEGFAULT)
          3 - odbc_blob (SEGFAULT)
          4 - odbc_desc (SEGFAULT)
         12 - odbc_prepare (SEGFAULT)
         13 - odbc_datetime (SEGFAULT)
         17 - odbc_unicode (SEGFAULT)
         18 - odbc_cursor (SEGFAULT)
         19 - odbc_dyn_cursor (SEGFAULT)
         21 - odbc_param (SEGFAULT)
         22 - odbc_result1 (SEGFAULT)
         23 - odbc_result2 (SEGFAULT)
		 
Core dump analysis shows that seg fault occurs at mysql_stmt_bind_param (stmt=0x2aa10c563a0, bind=0x2aa10cc3d00) 
https://github.com/mariadb-corporation/mariadb-connector-c/blob/62427520a5ba20e42fe51f5045062a7a9cadb466/libmariadb/mariadb_stmt.c#L1181
This is code from mariadb-connector-c repository which is getting cloned in mariadb-connector-odbc code. 

Here, memcpy(stmt->params, bind, sizeof(MYSQL_BIND) * stmt->param_count); fails on stmt->param_count. The value of stmt->param_count should be 1 however on s390x it read as 65536. This is due to different datatypes used in MariaDB connector ODBC source and MariaDB Connector-c code. 

a short (2 bytes) is being assigned into a void pointer (8 bytes) and then being casted into an unsigned int (4 bytes). 
&Stmt->ParamCountwhich is of datatype SQLSMALLINT (short int) is passed from MADB_DoExecute to function mysql_stmt_attr_set()and assigned to *value which is a void pointer and then its being casted into unsigned int as stmt->prebind_params= *(unsigned int *)value;
This will read as 65536 instead of 1 on big endian. This has no effect for little endian. 

To fix this we need to use another unsigned int variable while calling mysql_stmt_attr_set() on STMT_ATTR_PREBIND_PARAMS condition.   This fixes all the test cases on s390x and also works for Intel.   

Please review