### PR TITLE
Use pkg-config to find ODBC libraries

### DIFF
--- a/cmake/FindDM.cmake
+++ b/cmake/FindDM.cmake
@@ -60,68 +60,21 @@ ELSE()
     ENDIF()
   ELSE()
     MESSAGE(STATUS "${ODBC_CONFIG_EXEC} is not found ")
-    # Try to find the include directory, giving precedence to special variables
-    SET(LIB_PATHS /usr/local /usr /usr/local/Cellar/libiodbc/3.52.12)
+    FIND_PACKAGE(PkgConfig REQUIRED)
+    PKG_SEARCH_MODULE(ODBC REQUIRED ${ODBC_LIBS})
+    PKG_SEARCH_MODULE(ODBCINST REQUIRED ${ODBC_INSTLIBS})
 
-    IF("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
-      SET(LIB_PATHS "${LIB_PATHS}" "/usr/lib/x86_64-linux-gnu")
-
-      IF(EXISTS "/usr/lib64/")
-        SET(LIB_SUFFIX "lib64" "x86_64-linux-gnu")
-      ELSE()
-        SET(LIB_SUFFIX "lib" "x86_64-linux-gnu")
-      ENDIF()
-   
-    ELSE()
-      SET(LIB_PATHS "${LIB_PATHS}" "/usr/local/lib/i386-linux-gnu" "/usr/lib/i386-linux-gnu" "/usr/local/lib/i686-linux-gnu" "/usr/lib/i686-linux-gnu" "/usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}")
-      SET(LIB_SUFFIX "lib" "i386-linux-gnu" "i686-linux-gnu" "${CMAKE_LIBRARY_ARCHITECTURE}")
-    ENDIF()
-
-    FIND_PATH(ODBC_INCLUDE_DIR sql.h
-        HINTS ${DM_INCLUDE_DIR}
-              ${DM_DIR}
-              ENV DM_INCLUDE_DIR
-              ENV DM_DIR
-        PATHS /usr/local
-              /usr
-              /usr/local/Cellar/libiodbc/3.52.12
-        PATH_SUFFIXES include include/iodbc
-        NO_DEFAULT_PATH
-        DOC "Driver Manager Includes")
-    # Giving chance to cmake_(environment)path
-    FIND_PATH(ODBC_INCLUDE_DIR sql.h
-        DOC "Driver Manager Includes")
-
-    IF(ODBC_INCLUDE_DIR)
+    IF(ODBC_FOUND)
+      SET(ODBC_INCLUDE_DIR "${ODBC_INCLUDE_DIRS}")
       MESSAGE(STATUS "Found ODBC Driver Manager includes: ${ODBC_INCLUDE_DIR}")
     ENDIF()
     # Try to find DM libraries, giving precedence to special variables
-    FIND_PATH(ODBC_LIB_DIR "lib${ODBC_LIBS}.so"
-        HINTS ${DM_LIB_DIR}
-              ${DM_DIR}
-              ENV DM_LIB_DIR
-              ENV DM_DIR
-        PATHS ${LIB_PATHS}
-        PATH_SUFFIXES ${LIB_SUFFIX} 
-        NO_DEFAULT_PATH
-        DOC "Driver Manager Libraries")
-    FIND_PATH(ODBC_LIB_DIR "lib${ODBC_LIBS}.so"
-        DOC "Driver Manager Libraries")
-    FIND_PATH(ODBCINST_LIB_DIR "lib${ODBC_INSTLIBS}.so"
-        HINTS ${DM_LIB_DIR}
-              ${DM_DIR}
-              ENV DM_LIB_DIR
-              ENV DM_DIR
-        PATHS ${LIB_PATHS}
-        PATH_SUFFIXES ${LIB_SUFFIX} 
-        NO_DEFAULT_PATH
-        DOC "Driver Manager Libraries")
-    FIND_PATH(ODBCINST_LIB_DIR "lib${ODBC_INSTLIBS}.so"
-        DOC "Driver Manager Libraries")
+    SET(ODBC_LIB_DIR "${ODBC_LIBRARY_DIRS}")
+    SET(ODBCINST_LIB_DIR "${ODBCINST_LIBRARY_DIRS}")
   ENDIF()
 ENDIF()
 
-IF(ODBC_LIB_DIR AND ODBC_INCLUDE_DIR)
+IF(ODBC_FOUND AND ODBCINST_FOUND)
   MESSAGE(STATUS "Found ODBC Driver Manager libraries: ${ODBC_LIB_DIR} ${ODBCINST_LIB_DIR}")
   SET(DM_FOUND TRUE)
 ENDIF()


### PR DESCRIPTION
This was submitted to Debian in https://bugs.debian.org/942412 .
This makes the code substantially easier and might fix ODBC-268.

Using this will probably obsolete #51 and #52 as well.