### PR TITLE
Use CMAKE_LIBRARY_ARCHITECTURE in LIB_PATHS for odbc

### DIFF
--- a/cmake/FindDM.cmake
+++ b/cmake/FindDM.cmake
@@ -64,12 +64,12 @@ ELSE()
     SET(LIB_PATHS /usr/local /usr /usr/local/Cellar/libiodbc/3.52.12)
 
     IF("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
-      SET(LIB_PATHS "${LIB_PATHS}" "/usr/lib/x86_64-linux-gnu")
+      SET(LIB_PATHS "${LIB_PATHS}" "/usr/lib/x86_64-linux-gnu" "/usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}")
 
       IF(EXISTS "/usr/lib64/")
-        SET(LIB_SUFFIX "lib64" "x86_64-linux-gnu")
+        SET(LIB_SUFFIX "lib64" "${CMAKE_LIBRARY_ARCHITECTURE}")
       ELSE()
-        SET(LIB_SUFFIX "lib" "x86_64-linux-gnu")
+        SET(LIB_SUFFIX "lib" "${CMAKE_LIBRARY_ARCHITECTURE}")
       ENDIF()
    
     ELSE()


### PR DESCRIPTION
Another less-intrusive attempt to fix ODBC-268

Changes are contributed under the BSD-new license