### PR TITLE
test/types.c: fix build on `gcc-14`

### DIFF
--- a/test/types.c
+++ b/test/types.c
@@ -297,7 +297,7 @@ ODBC_TEST(t_nobigint)
   SQLLEN nlen= 0;
   SQLSMALLINT type= 0;
   SQLULEN     size= 0;
-  SQLCHAR* name[4];
+  SQLCHAR name[4];
 
   OK_SIMPLE_STMT(Stmt, "DROP TABLE IF EXISTS t_nobigint");
 


### PR DESCRIPTION
`gcc-14` turned some type punning warning into errors. This caused build to fails as:

    In file included from /build/mariadb-connector-odbc/test/types.c:26:
    /build/mariadb-connector-odbc/test/types.c: In function 't_nobigint':
    /build/mariadb-connector-odbc/test/types.c:313:49: error: passing argument 3 of 'SQLDescribeCol' from incompatible pointer type [-Wincompatible-pointer-types]
      313 |   CHECK_STMT_RC(hstmt, SQLDescribeCol(hstmt, 1, name, sizeof(name), NULL, &type, &size, NULL, NULL));
          |                                                 ^~~~
          |                                                 |
          |                                                 SQLCHAR ** {aka unsigned char **}
    /build/mariadb-connector-odbc/test/tap.h:652:24: note: in definition of macro 'CHECK_HANDLE_RC'
      652 |   SQLRETURN local_rc= (rc); \
          |                        ^~
    /build/mariadb-connector-odbc/test/types.c:313:3: note: in expansion of macro 'CHECK_STMT_RC'
      313 |   CHECK_STMT_RC(hstmt, SQLDescribeCol(hstmt, 1, name, sizeof(name), NULL, &type, &size, NULL, NULL));
          |   ^~~~~~~~~~~~~
    In file included from /build/mariadb-connector-odbc/test/tap.h:115:
    ...-unixODBC-2.3.12/include/sql.h:649:75: note: expected 'SQLCHAR *' {aka 'unsigned char *'} but argument is of type 'SQLCHAR **' {aka 'unsigned char **'}
      649 |                                       SQLUSMALLINT ColumnNumber, SQLCHAR *ColumnName,
          |                                                                  ~~~~~~~~~^~~~~~~~~~

The change fixes column name parameter to be a char array instead of pointer array.