### PR TITLE
[ODBC-411] Fix test failure on s390x

### DIFF
--- a/test/types.c
+++ b/test/types.c
@@ -324,8 +324,14 @@ ODBC_TEST(t_nobigint)
   is_num(size, 4);
   CHECK_STMT_RC(hstmt, SQLGetData(hstmt, 1, SQL_C_DEFAULT, &id, sizeof(id), &nlen));
 
-  is_num(0xFFFFFFFF0000000F, id);
-
+  if (little_endian())
+  {
+    is_num(0xFFFFFFFF0000000F, id);
+  }
+  else
+  {
+    is_num(0x0000000FFFFFFFFF, id);
+  }
   CHECK_STMT_RC(hstmt, SQLFreeStmt(hstmt, SQL_CLOSE));
 
   CHECK_STMT_RC(hstmt, SQLColumns(hstmt, NULL, SQL_NTS, NULL, SQL_NTS, "t_nobigint", SQL_NTS, NULL, SQL_NTS));


### PR DESCRIPTION
This fixes the `t_nobigint` test failure on s390x.

I am contributing my new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.