### PR TITLE
Fix GCC 14 -Wimplicit-int warnings

### DIFF
--- a/driver/class/ClientSidePreparedStatement.cpp
+++ b/driver/class/ClientSidePreparedStatement.cpp
@@ -236,7 +236,7 @@ namespace mariadb
     if (!metadata) {
       loadParametersData();
     }
-    return metadata.get();
+    return metadata.release();
   }
 
 

--- a/driver/class/Protocol.cpp
+++ b/driver/class/Protocol.cpp
@@ -646,10 +646,6 @@ namespace mariadb
       throw SQLException(mysql_error(connection.get()), mysql_sqlstate(connection.get()), mysql_errno(connection.get()));
     }
 
-    static const my_bool updateMaxLength= 1;
-
-    mysql_stmt_attr_set(stmtId, STMT_ATTR_UPDATE_MAX_LENGTH, &updateMaxLength);
-
     if (mysql_stmt_prepare(stmtId, sql.c_str(), static_cast<unsigned long>(sql.length())))
     {
       SQLString err(mysql_stmt_error(stmtId)), sqlState(mysql_stmt_sqlstate(stmtId));

--- a/driver/ma_api_internal.cpp
+++ b/driver/ma_api_internal.cpp
@@ -1496,7 +1496,7 @@ SQLRETURN MA_SQLGetData(SQLHSTMT StatementHandle,
   SQLLEN* StrLen_or_IndPtr)
 {
   MADB_Stmt* Stmt= (MADB_Stmt*)StatementHandle;
-  unsigned int i;
+  unsigned int i, columnCount;
   MADB_DescRecord* IrdRec;
 
   /* In case we don't have DM(it check for that) */
@@ -1522,9 +1522,9 @@ SQLRETURN MA_SQLGetData(SQLHSTMT StatementHandle,
   {
     return MADB_SetError(&Stmt->Error, MADB_ERR_HY090, NULL, 0);
   }
-
+  columnCount= Stmt->metadata->getColumnCount();
   /* reset offsets for other columns. Doing that here since "internal" calls should not do that */
-  for (i= 0; i < Stmt->metadata->getColumnCount(); i++)
+  for (i= 0; i < columnCount; i++)
   {
     if (i != Col_or_Param_Num - 1)
     {

--- a/driver/ma_bulk.cpp
+++ b/driver/ma_bulk.cpp
@@ -473,7 +473,7 @@ SQLRETURN MADB_ExecuteBulk(MADB_Stmt *Stmt, unsigned int ParamOffset)
 
   if (Stmt->stmt->isServerSide() && !MADB_ServerSupports(Stmt->Connection, MADB_CAPABLE_PARAM_ARRAYS))
   {
-    Stmt->stmt.reset(new ClientSidePreparedStatement(Stmt->Connection->guard.get(), STMT_STRING(Stmt), Stmt->Options.CursorType
+    MADB_CXX_RESET(Stmt->stmt, new ClientSidePreparedStatement(Stmt->Connection->guard.get(), STMT_STRING(Stmt), Stmt->Options.CursorType
       , Stmt->Query.NoBackslashEscape));
     // So far
     useCallbacks= false;

--- a/driver/ma_desc.cpp
+++ b/driver/ma_desc.cpp
@@ -123,7 +123,7 @@ MADB_Desc *MADB_DescInit(MADB_Dbc *Dbc,enum enum_madb_desc_type DescType, my_boo
 /* }}} */
 
 /* {{{ MADB_DescFree */
-SQLRETURN MADB_DescFree(MADB_Desc *Desc, my_bool RecordsOnly)
+SQLRETURN MADB_DescFree(MADB_Desc *Desc, bool RecordsOnly)
 {
   MADB_DescRecord *Record;
   unsigned int i;

--- a/driver/ma_desc.h
+++ b/driver/ma_desc.h
@@ -32,7 +32,7 @@ enum enum_madb_desc_type {MADB_DESC_APD= 0, MADB_DESC_ARD, MADB_DESC_IPD, MADB_D
 MADB_DescRecord *MADB_DescGetInternalRecord(MADB_Desc *Desc, SQLSMALLINT RecordNumber, SQLSMALLINT Type);
 
 MADB_Desc *MADB_DescInit(MADB_Dbc *Dbc, enum enum_madb_desc_type DescType, my_bool isExternal);
-SQLRETURN MADB_DescFree(MADB_Desc *Desc, my_bool RecordsOnly);
+SQLRETURN MADB_DescFree(MADB_Desc *Desc, bool RecordsOnly);
 SQLRETURN MADB_DescGetField(SQLHDESC DescriptorHandle,
                             SQLSMALLINT RecNumber,
                             SQLSMALLINT FieldIdentifier,

--- a/driver/ma_helper.cpp
+++ b/driver/ma_helper.cpp
@@ -257,9 +257,10 @@ MYSQL_RES *MADB_GetDefaultColumnValues(MADB_Stmt *Stmt, const MYSQL_FIELD *field
 
   for (i= 0; i < Stmt->metadata->getColumnCount(); i++)
   {
+    // TODO: Shouldn't it be really IRD here?
     MADB_DescRecord* Rec= MADB_DescGetInternalRecord(Stmt->Ard, i, MADB_DESC_READ);
 
-    if (!Rec->inUse || MADB_ColumnIgnoredInAllRows(Stmt->Ard, Rec) == TRUE)
+    if (!Rec || !Rec->inUse || MADB_ColumnIgnoredInAllRows(Stmt->Ard, Rec) == TRUE)
     {
       continue;
     }
@@ -864,7 +865,7 @@ void* GetBindOffset(MADB_Header& Header, void* Ptr, SQLULEN RowNumber, std::size
 }
 
 /* Checking if column ignored in all bound rows. Should hel*/
-BOOL MADB_ColumnIgnoredInAllRows(MADB_Desc *Desc, MADB_DescRecord *Rec)
+bool MADB_ColumnIgnoredInAllRows(MADB_Desc *Desc, MADB_DescRecord *Rec)
 {
   SQLULEN row;
   SQLLEN *IndicatorPtr;
@@ -873,13 +874,13 @@ BOOL MADB_ColumnIgnoredInAllRows(MADB_Desc *Desc, MADB_DescRecord *Rec)
   {
     IndicatorPtr= (SQLLEN *)GetBindOffset(Desc->Header, Rec->IndicatorPtr, row, sizeof(SQLLEN));
 
-    if (IndicatorPtr == NULL || *IndicatorPtr != SQL_COLUMN_IGNORE)
+    if (IndicatorPtr == nullptr || *IndicatorPtr != SQL_COLUMN_IGNORE)
     {
-      return FALSE;
+      return false;
     }
   }
 
-  return TRUE;
+  return true;
 }
 
 

--- a/driver/ma_helper.h
+++ b/driver/ma_helper.h
@@ -53,7 +53,7 @@ const char *  MADB_GetTypeName(const MYSQL_FIELD *Field);
 my_bool MADB_CheckPtrLength(SQLINTEGER MaxLength, char *Ptr, SQLINTEGER NameLen);
 std::size_t getArrayStep(MADB_Header& header, std::size_t pointedSize);
 void *  GetBindOffset(MADB_Header& DescHeader, void *Ptr, SQLULEN RowNumber, size_t PtrSize);
-BOOL    MADB_ColumnIgnoredInAllRows(MADB_Desc *Desc, MADB_DescRecord *Rec);
+bool    MADB_ColumnIgnoredInAllRows(MADB_Desc *Desc, MADB_DescRecord *Rec);
 
 SQLRETURN     MADB_DaeStmt(MADB_Stmt *Stmt, SQLUSMALLINT Operation);
 MYSQL_RES *   MADB_GetDefaultColumnValues(MADB_Stmt *Stmt, const MYSQL_FIELD *fields);
@@ -108,5 +108,8 @@ extern my_bool DummyError;
 }
 
 #define MADB_FRACTIONAL_PART(_decimals) ((_decimals) > 0 ? (_decimals) + 1/*Decimal point*/ : 0)
+
+#define MADB_DELETE(PTR) do {delete (PTR); (PTR)= nullptr;} while(false)
+#define MADB_CXX_RESET(PTR,NEWPTR) do {delete (PTR); (PTR)= (NEWPTR);} while(false)
 
 #endif

--- a/driver/ma_info.cpp
+++ b/driver/ma_info.cpp
@@ -247,10 +247,10 @@ SQLRETURN MADB_GetTypeInfo(SQLHSTMT StatementHandle,
 
   std::vector<std::vector<mariadb::bytes_view>> row;
 
-  Stmt->stmt.reset();
+  MADB_DELETE(Stmt->stmt);
   if (DataType == SQL_ALL_TYPES)
   {
-    Stmt->rs.reset(ResultSet::createResultSet(TypeInfoColumnName, TypeInfoColumnType, *TypeInfo));
+    MADB_CXX_RESET(Stmt->rs, ResultSet::createResultSet(TypeInfoColumnName, TypeInfoColumnType, *TypeInfo));
   }
   else
   {
@@ -262,7 +262,7 @@ SQLRETURN MADB_GetTypeInfo(SQLHSTMT StatementHandle,
         row.push_back(cit);
       }
     }
-    Stmt->rs.reset(ResultSet::createResultSet(TypeInfoColumnName, TypeInfoColumnType, row));
+    MADB_CXX_RESET(Stmt->rs, ResultSet::createResultSet(TypeInfoColumnName, TypeInfoColumnType, row));
   }
 
   Stmt->State= MADB_SS_EXECUTED;

--- a/driver/ma_odbc.h
+++ b/driver/ma_odbc.h
@@ -291,9 +291,9 @@ struct MADB_Stmt
   long long                 AffectedRows= 0;
   MADB_Dbc                  *Connection;
   struct st_ma_stmt_methods *Methods;
-  Unique::ResultSet         rs;
-  Unique::PreparedStatement stmt;
-  Unique::ResultSetMetaData metadata;
+  ResultSet*                rs= nullptr;
+  PreparedStatement*        stmt= nullptr;
+  mariadb::ResultSetMetaData* metadata= nullptr;
   Unique::MYSQL_RES         DefaultsResult;
   MADB_DescRecord           *PutDataRec= nullptr;
   MADB_Stmt                 *DaeStmt= nullptr;

--- a/driver/ma_parse.cpp
+++ b/driver/ma_parse.cpp
@@ -119,7 +119,7 @@ void MADB_QUERY::reset()
   Original.assign("");
   RefinedText.assign("");
   Tokens.clear();
-  PoorManParsing= ReturnsResult= false;
+  PoorManParsing= false;
 }
 
 int MADB_ParseQuery(MADB_QUERY * Query)
@@ -396,8 +396,6 @@ int ParseQuery(MADB_QUERY *Query)
       {
         /* We are currently at 2nd token of statement, and getting previous token position from Tokens array*/
         StmtType= MADB_GetQueryType(MADB_Token(Query, Query->Tokens.size() - 2), p);
-
-        Query->ReturnsResult= Query->ReturnsResult || !QUERY_DOESNT_RETURN_RESULT(StmtType);
 
         /* If we on first statement, setting QueryType*/
         if (Query->Tokens.size() == 2)

--- a/driver/ma_parse.h
+++ b/driver/ma_parse.h
@@ -61,8 +61,6 @@ typedef struct {
   SQLString     RefinedText;
   enum enum_madb_query_type QueryType= MADB_QUERY_NO_RESULT;
   bool          MultiStatement= false;
-  /* Keeping it so far */
-  bool       ReturnsResult= false;
   bool       PoorManParsing= false;
 
   bool       BatchAllowed= false;

--- a/driver/ma_statement.cpp
+++ b/driver/ma_statement.cpp
@@ -78,8 +78,8 @@ SQLRETURN MADB_StmtFree(MADB_Stmt *Stmt, SQLUSMALLINT Option)
   case SQL_CLOSE:
     if (Stmt->stmt)
     {
-      if (Stmt->Ird)
-        MADB_DescFree(Stmt->Ird, TRUE);
+      /*if (Stmt->Ird)
+        MADB_DescFree(Stmt->Ird, true);*/
       if (Stmt->State > MADB_SS_PREPARED)
       {
         MDBUG_C_PRINT(Stmt->Connection, "Closing resultset", Stmt->stmt);
@@ -100,8 +100,8 @@ SQLRETURN MADB_StmtFree(MADB_Stmt *Stmt, SQLUSMALLINT Option)
       MADB_DELETE(Stmt->metadata);
      
       MADB_FREE(Stmt->result);
-      MADB_FREE(Stmt->CharOffset);
-      MADB_FREE(Stmt->Lengths);
+      /*MADB_FREE(Stmt->CharOffset);
+      MADB_FREE(Stmt->Lengths);*/
 
       RESET_STMT_STATE(Stmt);
       RESET_DAE_STATUS(Stmt);
@@ -736,8 +736,7 @@ SQLRETURN MADB_ExecutePositionedUpdate(MADB_Stmt *Stmt, bool ExecDirect)
       (Stmt->PositionedCursor->UniqueIndex[0] != 0 && IndexIdx <= Stmt->PositionedCursor->UniqueIndex[0] && j == Stmt->PositionedCursor->UniqueIndex[IndexIdx]))
     {
       SQLLEN Length;
-      MADB_DescRecord* Rec= MADB_DescGetInternalRecord(Stmt->PositionedCursor->Ard, j, MADB_DESC_WRITE/* Should be WRITE so it gets created
-                                                                                                      if it does not exist */);
+      MADB_DescRecord* Rec= MADB_DescGetInternalRecord(Stmt->PositionedCursor->Ard, j, MADB_DESC_WRITE/* Should be WRITE so it gets created                                                                                                     if it does not exist */);
       SQLUSMALLINT ParamNumber= 0;
 
       Length= Rec->OctetLength;
@@ -982,7 +981,9 @@ void MADB_Stmt::ProcessRsMetadata()
 {
   /* I don't think we can reliably establish the fact that we do not need to re-fetch the metadata, thus we are re-fetching always
        The fact that we have resultset has been established above in "if" condition(fields count is > 0) */
+  //if (!metadata || metadata->getColumnCount() == 0 || metadata->getFields() == nullptr) {
   FetchMetadata(this);
+  //}
   MADB_StmtResetResultStructures(this);
   MADB_DescSetIrdMetadata(this, metadata->getFields(), metadata->getColumnCount());
 

--- a/driver/ma_statement.h
+++ b/driver/ma_statement.h
@@ -116,7 +116,6 @@ SQLRETURN    MADB_DoExecute         (MADB_Stmt *Stmt);
 #define MADB_POS_COMM_IDX_FIELD_COUNT(aStmt) (MADB_STMT_HAS_UNIQUE_IDX((aStmt)->PositionedCursor)?(aStmt)->PositionedCursor->UniqueIndex[0]:MADB_STMT_COLUMN_COUNT((aStmt)->PositionedCursor))
 #define MADB_STMT_FORGET_NEXT_POS(aStmt) (aStmt)->Cursor.Next= -1
 #define MADB_STMT_RESET_CURSOR(aStmt) (aStmt)->Cursor.Position= 0; MADB_STMT_FORGET_NEXT_POS(aStmt)
-#define MADB_STMT_CLOSE_STMT(aStmt)  (aStmt)->stmt.reset()
 #define MADB_STMT_SHOULD_STREAM(_a) (DSN_OPTION((_a)->Connection, MADB_OPT_FLAG_NO_CACHE) &&\
   (_a)->Options.CursorType == SQL_CURSOR_FORWARD_ONLY)
 /* Checks if given Stmt handle is currently streaming (prev variant (MADB_STMT_SHOULD_STREAM(_a) && STMT_EXECUTED(_a) && MADB_STMT_COLUMN_COUNT(_a) > 0) */

--- a/test/basic.c
+++ b/test/basic.c
@@ -1,6 +1,6 @@
 /*
   Copyright (c) 2001, 2012, Oracle and/or its affiliates. All rights reserved.
-                2013, 2023 MariaDB Corporation AB
+                2013, 2024 MariaDB Corporation AB
 
   The MySQL Connector/ODBC is licensed under the terms of the GPLv2
   <http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>, like most
@@ -80,14 +80,14 @@ ODBC_TEST(simple_test)
   CHECK_STMT_RC(Stmt, SQLFreeStmt(Stmt, SQL_CLOSE));
 
   OK_SIMPLE_STMTW(Stmt, CW("DROP TABLE IF EXISTS smpltest"));
-  OK_SIMPLE_STMTW(Stmt, CW("CREATE TABLE smpltest (a int, b varchar(25))"));
+  OK_SIMPLE_STMTW(Stmt, CW("CREATE TABLE smpltest (a INT, b VARCHAR(25))"));
   OK_SIMPLE_STMTW(Stmt, CW("INSERT INTO smpltest VALUES (1, 'Row no 1')"));
   OK_SIMPLE_STMTW(Stmt, CW("INSERT INTO smpltest VALUES (2, 'Row no 2')"));
   
   CHECK_STMT_RC(Stmt, SQLPrepareW(Stmt, CW("SELECT a, b FROM smpltest"), SQL_NTS));
   CHECK_STMT_RC(Stmt, SQLExecute(Stmt));
   
-  SQLFetch(Stmt);
+  CHECK_STMT_RC(Stmt, SQLFetch(Stmt));
   SQLGetData(Stmt, 1, SQL_C_USHORT, &value, sizeof(value), 0);
   SQLGetData(Stmt, 2, SQL_C_WCHAR, Buffer, sizeof(Buffer), 0);
   is_num(value, 1);

--- a/test/desc.c
+++ b/test/desc.c
@@ -171,7 +171,7 @@ ODBC_TEST(t_sqlbindcol_count_reset)
                                SQL_IS_INTEGER, NULL));
   is_num(count, 0);
 
-  OK_SIMPLE_STMT(Stmt, "select 1,2,3,4,5");
+  OK_SIMPLE_STMT(Stmt, "SELECT 1,2,3,4,5");
 
   CHECK_DESC_RC(ard, SQLGetDescField(ard, 0, SQL_DESC_COUNT, &count,
                                SQL_IS_INTEGER, NULL));
@@ -225,7 +225,7 @@ ODBC_TEST(t_desc_default_type)
   SQLHANDLE ard, apd;
   SQLINTEGER inval= 20, outval= 0;
 
-  CHECK_STMT_RC(Stmt, SQLPrepare(Stmt, (SQLCHAR *)"select ?", SQL_NTS));
+  CHECK_STMT_RC(Stmt, SQLPrepare(Stmt, (SQLCHAR *)"SELECT ?", SQL_NTS));
   CHECK_STMT_RC(Stmt, SQLGetStmtAttr(Stmt, SQL_ATTR_APP_PARAM_DESC,
                                 &apd, 0, NULL));
   CHECK_STMT_RC(Stmt, SQLGetStmtAttr(Stmt, SQL_ATTR_APP_ROW_DESC,

--- a/test/relative.c
+++ b/test/relative.c
@@ -838,7 +838,7 @@ ODBC_TEST(bench2)
     "i80 int,i81 int,i82 int,i83 int,i84 int,i85 int,i86 int,i87 int,i88 int,i89 int,i90 int,i91 int,i92 int,i93 int,i94 int,i95 int,i96 int,i97 int,i98 int,i99 int,i100 int)", SQL_NTS);
   SQLExecDirect(Stmt, (SQLCHAR*)"INSERT INTO test100 value (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,"
     "42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100)", SQL_NTS);*/
-  for (auto j= 0; j < 20000; ++j) {
+  for (int j= 0; j < 20000; ++j) {
     SQLExecDirect(Stmt, (SQLCHAR*)"SELECT * FROM test100", SQL_NTS);
 
     while ((rc= SQLFetch(Stmt)) != SQL_NO_DATA && SQL_SUCCEEDED(rc)) {
@@ -858,7 +858,7 @@ ODBC_TEST(bench3)
   SQLRETURN rc= SQL_SUCCESS;
 
   SQLPrepare(Stmt, (SQLCHAR*)"SELECT * FROM test100", SQL_NTS);
-  for (auto j= 0; j < 500; ++j) {
+  for (int j= 0; j < 500; ++j) {
     SQLExecute(Stmt);
 
     while ((rc= SQLFetch(Stmt)) != SQL_NO_DATA && SQL_SUCCEEDED(rc)) {

--- a/test/relative.c
+++ b/test/relative.c
@@ -858,12 +858,13 @@ ODBC_TEST(bench3)
   SQLRETURN rc= SQL_SUCCESS;
 
   SQLPrepare(Stmt, (SQLCHAR*)"SELECT * FROM test100", SQL_NTS);
-  for (auto j= 0; j < 50; ++j) {
+  for (auto j= 0; j < 500; ++j) {
     SQLExecute(Stmt);
 
     while ((rc= SQLFetch(Stmt)) != SQL_NO_DATA && SQL_SUCCEEDED(rc)) {
       for (size_t i= 0; i < 100; ++i) {
         SQLGetData(Stmt, (SQLUSMALLINT)(i + 1), SQL_INTEGER, &id, 0, NULL);
+        is_num(id, i + 1);
       }
     }
     SQLFreeStmt(Stmt, SQL_CLOSE);

--- a/test/relative.c
+++ b/test/relative.c
@@ -825,10 +825,58 @@ ODBC_TEST(bench1)
 }
 
 
+ODBC_TEST(bench2)
+{
+  SQLINTEGER id= 0;
+  SQLRETURN rc= SQL_SUCCESS;
+
+  /*SQLExecDirect(Stmt, (SQLCHAR*)"DROP TABLE test100", SQL_NTS);
+  SQLExecDirect(Stmt, (SQLCHAR*)"CREATE TABLE test100 (i1 int,i2 int,i3 int,i4 int,i5 int,i6 int,i7 int,i8 int,i9 int,i10 int,i11 int,i12 int,i13 int,i14 int,i15 int,i16 int,"
+    "i17 int,i18 int,i19 int,i20 int,i21 int,i22 int,i23 int,i24 int,i25 int,i26 int,i27 int,i28 int,i29 int,i30 int,i31 int,i32 int,i33 int,i34 int,i35 int,i36 int,i37 int,"
+    "i38 int,i39 int,i40 int,i41 int,i42 int,i43 int,i44 int,i45 int,i46 int,i47 int,i48 int,i49 int,i50 int,i51 int,i52 int,i53 int,i54 int,i55 int,i56 int,i57 int,i58 int,"
+    "i59 int,i60 int,i61 int,i62 int,i63 int,i64 int,i65 int,i66 int,i67 int,i68 int,i69 int,i70 int,i71 int,i72 int,i73 int,i74 int,i75 int,i76 int,i77 int,i78 int,i79 int,"
+    "i80 int,i81 int,i82 int,i83 int,i84 int,i85 int,i86 int,i87 int,i88 int,i89 int,i90 int,i91 int,i92 int,i93 int,i94 int,i95 int,i96 int,i97 int,i98 int,i99 int,i100 int)", SQL_NTS);
+  SQLExecDirect(Stmt, (SQLCHAR*)"INSERT INTO test100 value (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,"
+    "42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100)", SQL_NTS);*/
+  for (auto j= 0; j < 20000; ++j) {
+    SQLExecDirect(Stmt, (SQLCHAR*)"SELECT * FROM test100", SQL_NTS);
+
+    while ((rc= SQLFetch(Stmt)) != SQL_NO_DATA && SQL_SUCCEEDED(rc)) {
+      for (size_t i= 0; i < 100; ++i) {
+        SQLGetData(Stmt, (SQLUSMALLINT)(i + 1), SQL_INTEGER, &id, 0, NULL);
+      }
+    }
+    SQLFreeStmt(Stmt, SQL_CLOSE);
+  }
+  return OK;
+}
+
+
+ODBC_TEST(bench3)
+{
+  SQLINTEGER id= 0;
+  SQLRETURN rc= SQL_SUCCESS;
+
+  SQLPrepare(Stmt, (SQLCHAR*)"SELECT * FROM test100", SQL_NTS);
+  for (auto j= 0; j < 50; ++j) {
+    SQLExecute(Stmt);
+
+    while ((rc= SQLFetch(Stmt)) != SQL_NO_DATA && SQL_SUCCEEDED(rc)) {
+      for (size_t i= 0; i < 100; ++i) {
+        SQLGetData(Stmt, (SQLUSMALLINT)(i + 1), SQL_INTEGER, &id, 0, NULL);
+      }
+    }
+    SQLFreeStmt(Stmt, SQL_CLOSE);
+  }
+  return OK;
+}
+
 MA_ODBC_TESTS my_tests[]=
 {
   //{bench, "bench"},
   //{bench1, "bench1"},
+  //{bench2, "bench2"},
+  //{bench3, "bench3"},
   {t_relative, "t_relative"},
   {t_relative1, "t_relative1"},
   {t_relative2, "t_relative2"},

--- a/test/tap.h
+++ b/test/tap.h
@@ -1020,7 +1020,7 @@ int ReadInfoOneTime(HDBC Connection, HSTMT Stmt)
   }
 
   CHECK_STMT_RC(Connection, SQLGetInfo(Connection, SQL_DRIVER_VER, DriverVersion, sizeof(DriverVersion), &len));
-  OK_SIMPLE_STMT(Stmt, "SELECT 1 FROM dual where @@performance_schema=1");
+  OK_SIMPLE_STMT(Stmt, "SELECT 1 FROM dual WHERE @@performance_schema=1");
   if (SQL_SUCCEEDED(SQLFetch(Stmt)))
   {
     PerfSchema= TRUE;


### PR DESCRIPTION
The compilation results in warnings about auto defaulting to int.

test/relative.c:841:13: error: type defaults to ‘int’ in declaration of ‘j’ [-Wimplicit-int]
  841 |   for (auto j= 0; j < 20000; ++j) {
      |             ^