### PR TITLE
Removed the mariadb subdir from the destination of sqlmariadb.h

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -20,5 +20,5 @@
 
 INSTALL(FILES
    mariadb/sqlmariadb.h
-   DESTINATION ${INSTALL_INCLUDEDIR}/mariadb
+   DESTINATION ${INSTALL_INCLUDEDIR}
    COMPONENT Development)


### PR DESCRIPTION
as it is supposed to be installed inside of include/mariadb and since INSTALL_INCLUDEDIR is being set to include/mariadb in all deb, rpm and default install configurations inside cmake/install.cmake, the destination of ${INSTALL_INCLUDEDIR}|/mariadb caused it to be installed to include/mariadb/mariadb