### PR TITLE
Fix compilation with GCC 15

### DIFF
--- a/driver/class/ColumnDefinition.h
+++ b/driver/class/ColumnDefinition.h
@@ -23,6 +23,7 @@
 
 #include <memory>
 #include <map>
+#include <cstdint>
 
 #include "mysql.h"
 

--- a/driver/interface/CmdInformation.h
+++ b/driver/interface/CmdInformation.h
@@ -23,6 +23,7 @@
 
 #include <vector>
 #include <memory>
+#include <cstdint>
 
 namespace mariadb
 {

--- a/driver/interface/Row.h
+++ b/driver/interface/Row.h
@@ -24,6 +24,7 @@
 #include <sstream>
 #include <vector>
 #include <memory>
+#include <cstdint>
 
 #include "mysql.h"
 


### PR DESCRIPTION
Fedora adopted GCC 15 in Fedora 42:
    https://fedoraproject.org/wiki/Changes/GNUToolchainF42

I'm now proposing a patch we carry from that moment.
  https://src.fedoraproject.org/rpms/mariadb-connector-odbc/c/70ebae?branch=rawhide