### PR TITLE
Remove macOS builds from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,19 +16,11 @@ import: mariadb-corporation/connector-test-machine:common-build.yml@master
 jobs:
   fast_finish: true
   allow_failures:
-    - os: osx
     - os: windows
     - os: linux
       arch: s390x
       dist: focal
   include:
-    - stage: Language
-      os: osx
-      compiler: clang
-      before_script:
-        - brew install openssl
-        - brew install libiodbc
-      name: "OSX"
     - stage: Language
       os: linux
       arch: s390x


### PR DESCRIPTION
This PR removes macOS build jobs from Travis CI as macOS builds are no longer supported in Travis CI.
**_Note_** : I am contributing my new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.
