### PR TITLE
Add missing <cstdint> includes

### DIFF
--- a/driver/interface/Exception.h
+++ b/driver/interface/Exception.h
@@ -21,6 +21,7 @@
 #ifndef _EXCEPTION_H_
 #define _EXCEPTION_H_
 
+#include <cstdint>
 #include <stdexcept>
 #include "class/SQLString.h"
 

--- a/driver/template/CArray.h
+++ b/driver/template/CArray.h
@@ -24,6 +24,7 @@
 #include <initializer_list>
 #include <vector>
 #include <stdexcept>
+#include <cstdint>
 #include <cstring>
 #include <string>
 


### PR DESCRIPTION
These files use types from <cstdint> without including it.  Without the includes, the build fails for musl.