### PR TITLE
Disable invalid-handle check under MSan

### DIFF
--- a/test/unicode.c
+++ b/test/unicode.c
@@ -259,11 +259,21 @@ ODBC_TEST(sqlchar)
   FAIL_IF(SQLFetch(hstmt1) != SQL_NO_DATA_FOUND, "eof expected");
 
   CHECK_STMT_RC(hstmt1, SQLFreeStmt(hstmt1, SQL_DROP));
+  
+#ifndef __has_feature
+#  define __has_feature(x) 0
+#endif
+#ifndef MEMCHECK_SKIP_TEST
   // We probably could do that in driver as well, TODO: but do we really need
   if (using_dm())
   {
+#if defined(__clang__) && __has_feature(memory_sanitizer)
+    diag("Skipping invalid-handle check under MSan");
+#else
     is_num(SQLFreeHandle(SQL_HANDLE_STMT, hstmt1), SQL_INVALID_HANDLE);
+#endif
   }
+#endif
   CHECK_DBC_RC(hdbc1, SQLDisconnect(hdbc1));
   CHECK_DBC_RC(hdbc1, SQLFreeConnect(hdbc1));
 


### PR DESCRIPTION
The invalid-handle check was disabled in a55878f4baa061fc9943228beecb91367d7d08fe for Valgrind and MSan issues an warning originating from the Driver Manager, during the same call;

```
==26==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x7a902a23c3a2 in __validate_stmt /msan-build/DriverManager/__handles.c:1375:20
    #1 0x7a902a1fc264 in __SQLFreeHandle /msan-build/DriverManager/SQLFreeHandle.c:398:19
    #2 0x559ce0edbbb9 in sqlchar /home/buildbot/odbc_build/source/test/unicode.c:270:12
    #3 0x559ce0ed4419 in run_tests_ex /home/buildbot/odbc_build/source/test/tap.h:1182:11
    #4 0x7a9029eccca7  (/lib/x86_64-linux-gnu/libc.so.6+0x29ca7) (BuildId: 58749c528985eab03e6700ebc1469fa50aa41219)
    #5 0x7a9029eccd64 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29d64) (BuildId: 58749c528985eab03e6700ebc1469fa50aa41219)
    #6 0x559ce0e2e670 in _start (/home/buildbot/odbc_build/build/bintar/test/odbc_unicode+0x34670) (BuildId: 92f183f3e775737cd445db531d16f5654952b845)

SUMMARY: MemorySanitizer: use-of-uninitialized-value /msan-build/DriverManager/__handles.c:1375:20 in __validate_stmt
  ORIGIN: invalid (0). Might be a bug in MemorySanitizer origin tracking.
    This could still be a bug in your code, too!
Exiting
```